### PR TITLE
Update to rubocop 1.0, deprecate Ruby < 2.6, add 2.7 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,18 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.9"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.7"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
         default: "2.6.5"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7.2"
 
 commands:
   pre-setup:
@@ -39,12 +33,18 @@ commands:
       - checkout
   bundle-install:
     steps:
+      - run:
+          name: "Install bundler 1.17.3"
+          command: |
+            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler:1.17.3
       - restore_cache:
           keys:
             - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
             - gem-cache-{{ arch }}-{{ .Branch }}
             - gem-cache
-      - run: bundle check || bundle install --path vendor/bundle
+      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
       - save_cache:
           key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
@@ -86,7 +86,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +96,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +106,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +114,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:
@@ -144,3 +125,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
+  NewCops: enable
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -7,8 +8,6 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
     - log/**/*
-    - Rakefile
-    - gruf-rspec.gemspec
 
 Lint/AmbiguousOperator:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Drop support for Ruby < 2.6, add 2.7 tests
+- Update rubocop to 1.0
+
 ### 0.2.2
 
 * Loosen rspec dependency

--- a/Gemfile
+++ b/Gemfile
@@ -20,15 +20,3 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
-
-group :development, :test do
-  gem 'rubocop',                '~> 0.78'
-end
-
-group :test do
-  gem 'bundler-audit',          '~> 0.6'
-  gem 'null-logger',            '~> 0.1'
-  gem 'rspec',                  '~> 3.8'
-  gem 'rspec_junit_formatter',  '~> 0.4'
-  gem 'simplecov',              '~> 0.16', require: false
-end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gruf/rspec/version'
 
@@ -26,18 +26,22 @@ Gem::Specification.new do |spec|
   spec.email         = ['splittingred@gmail.com']
   spec.license       = 'MIT'
 
-  spec.summary       = %q{RSpec assistance library for gruf}
-  spec.description   = %q{RSpec assistance library for gruf, including testing helpers}
+  spec.summary       = 'RSpec assistance library for gruf'
+  spec.description   = 'RSpec assistance library for gruf, including testing helpers'
   spec.homepage      = 'https://github.com/bigcommerce/gruf-rspec'
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-rspec.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'rake', '>= 12.3'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler-audit', '~> 0.6'
+  spec.add_development_dependency 'pry', '>= 0.13'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
+  spec.add_development_dependency 'rubocop', '~> 0.82'
+  spec.add_development_dependency 'simplecov', '~> 0.15'
 
   spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
   spec.add_dependency 'rspec', '>= 3.8'

--- a/lib/gruf/rspec.rb
+++ b/lib/gruf/rspec.rb
@@ -62,7 +62,7 @@ GRUF_RSPEC_RUNNER.configure do |config|
         message: request
       )
       resp = @gruf_controller.call(@gruf_controller.request.method_key)
-      block.call(resp) if block&.is_a?(Proc)
+      block.call(resp) if block.is_a?(Proc)
       resp
     end
 

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -24,12 +24,14 @@ module Gruf
     # Represents configuration settings for the system
     #
     module Configuration
+      DEFAULT_RSPEC_PATH = '/spec/rpc/'
+
       VALID_CONFIG_KEYS = {
         authentication_hydrators: {
           base: Gruf::Rspec::AuthenticationHydrators::Base,
           basic: Gruf::Rspec::AuthenticationHydrators::Basic
         },
-        rpc_spec_path: ENV.fetch('RPC_SPEC_PATH', '/spec/rpc/').to_s,
+        rpc_spec_path: ENV.fetch('RPC_SPEC_PATH', DEFAULT_RSPEC_PATH).to_s
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys
@@ -71,9 +73,9 @@ module Gruf
       #
       def reset
         VALID_CONFIG_KEYS.each do |k, v|
-          send((k.to_s + '='), v)
+          send("#{k}=", v)
         end
-        self.rpc_spec_path = '/spec/rpc/'
+        self.rpc_spec_path = ::ENV.fetch('RPC_SPEC_PATH', DEFAULT_RSPEC_PATH).to_s
         options
       end
     end

--- a/spec/gruf/rspec/configuration_spec.rb
+++ b/spec/gruf/rspec/configuration_spec.rb
@@ -24,10 +24,10 @@ end
 RSpec.describe Gruf::Rspec::Configuration do
   let(:obj) { TestConfiguration.new }
 
-  describe '.reset' do
+  describe '#reset' do
     subject { obj.rpc_spec_path }
 
-    it 'should reset config vars to default' do
+    it 'resets config vars to default' do
       obj.configure do |c|
         c.rpc_spec_path = '/spec/gruf/'
       end
@@ -36,13 +36,13 @@ RSpec.describe Gruf::Rspec::Configuration do
     end
   end
 
-  describe '.options' do
+  describe '#options' do
     subject { obj.options }
     before do
       obj.reset
     end
 
-    it 'should return the options hash' do
+    it 'returns the options hash' do
       expect(obj.options).to be_a(Hash)
       expect(obj.options[:rpc_spec_path]).to eq '/spec/rpc/'
     end

--- a/spec/gruf/rspec/error_matcher_spec.rb
+++ b/spec/gruf/rspec/error_matcher_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe Gruf::Rspec::ErrorMatcher do
     )
   end
 
-  describe '.valid?' do
+  describe '#valid?' do
     subject { error_matcher.valid? }
 
     context 'when the error class matches' do
       let(:rpc_call_proc) { Proc.new { raise expected_error_class } }
 
-      it 'should be valid' do
+      it 'returns true' do
         expect(subject).to be_truthy
       end
 
@@ -47,7 +47,7 @@ RSpec.describe Gruf::Rspec::ErrorMatcher do
           end
         end
 
-        it 'should not be valid' do
+        it 'returns false' do
           expect(subject).to be_falsey
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe Gruf::Rspec::ErrorMatcher do
           end
         end
 
-        it 'should be valid' do
+        it 'returns true' do
           expect(subject).to be_truthy
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe Gruf::Rspec::ErrorMatcher do
     context 'when the error class does not match' do
       let(:rpc_call_proc) { Proc.new { raise GRPC::InvalidArgument } }
 
-      it 'should not be valid' do
+      it 'returns false' do
         expect(subject).to be_falsey
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe Gruf::Rspec::ErrorMatcher do
     context 'when no error is thrown' do
       let(:rpc_call_proc) { Proc.new { true } }
 
-      it 'should not be valid' do
+      it 'returns false' do
         expect(subject).to be_falsey
       end
     end

--- a/spec/gruf/rspec/metadata_factory_spec.rb
+++ b/spec/gruf/rspec/metadata_factory_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Gruf::Rspec::MetadataFactory do
   let(:metadata) { {} }
   let(:factory) { described_class.new(options) }
 
-  describe '.build' do
+  describe '#build' do
     subject { factory.build(metadata) }
 
     context 'when using basic auth' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,11 +18,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'bundler/setup'
 require_relative 'simplecov_helper'
-require 'grpc'
 require 'gruf'
 require 'gruf/rspec'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each {|f| require f }
+Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each {|f| require f }
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## What?

- Updates to rubocop 1.0
- Deprecates support for Ruby < 2.6
- Adds 2.7 tests

----

@bigcommerce/ruby @bigcommerce/platform-engineering @bigcommerce/oss-maintainers 