### PR TITLE
Controller Matcher Configuration

### DIFF
--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -57,13 +57,13 @@ module Gruf
       # @return [Hash] The configuration for gruf, represented as a Hash
       #
       def options
-        opts = {}
-        VALID_CONFIG_KEYS.each_key do |k|
-          next opts.merge!(k => ENV.fetch('RPC_SPEC_PATH', send(k))) if k == :rpc_spec_path
+        {}.tap do |opts|
+          VALID_CONFIG_KEYS.each_key do |k|
+            next opts.merge!(k => ENV.fetch('RPC_SPEC_PATH', send(k))) if k == :rpc_spec_path
 
-          opts.merge!(k => send(k))
+            opts.merge!(k => send(k))
+          end
         end
-        opts
       end
 
       ##

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -73,7 +73,7 @@ module Gruf
         VALID_CONFIG_KEYS.each do |k, v|
           send((k.to_s + '='), v)
         end
-        self.rpc_spec_path = '/spec/rpc/'
+        self.rpc_spec_path = VALID_CONFIG_KEYS[:rpc_spec_path]
         options
       end
     end

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -29,7 +29,7 @@ module Gruf
           base: Gruf::Rspec::AuthenticationHydrators::Base,
           basic: Gruf::Rspec::AuthenticationHydrators::Basic
         },
-        rpc_spec_path: ENV.fetch('RPC_SPEC_PATH', '/spec/rpc/').to_s,
+        rpc_spec_path: '/spec/rpc/'
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys
@@ -70,10 +70,7 @@ module Gruf
       # @return [Hash] options The reset options hash
       #
       def reset
-        VALID_CONFIG_KEYS.each do |k, v|
-          send((k.to_s + '='), v)
-        end
-        self.rpc_spec_path = VALID_CONFIG_KEYS[:rpc_spec_path]
+        VALID_CONFIG_KEYS.each { |k, v| send("#{k}=", v) }
         options
       end
     end

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -60,9 +60,9 @@ module Gruf
       def options
         {}.tap do |opts|
           VALID_CONFIG_KEYS.each_key do |k|
-            next opts.merge!(k => ENV.fetch('RPC_SPEC_PATH', send(k))) if k == :rpc_spec_path
+            next opts[k] = ENV.fetch('RPC_SPEC_PATH', send(k)) if k == :rpc_spec_path
 
-            opts.merge!(k => send(k))
+            opts[k] = send(k)
           end
         end
       end

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -25,13 +25,12 @@ module Gruf
     #
     module Configuration
       DEFAULT_RSPEC_PATH = '/spec/rpc/'
-
       VALID_CONFIG_KEYS = {
         authentication_hydrators: {
           base: Gruf::Rspec::AuthenticationHydrators::Base,
           basic: Gruf::Rspec::AuthenticationHydrators::Basic
         },
-        rpc_spec_path: '/spec/rpc/'
+        rpc_spec_path: DEFAULT_RSPEC_PATH
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -74,7 +74,7 @@ module Gruf
       #
       def reset
         VALID_CONFIG_KEYS.each { |k, v| send("#{k}=", v) }
-        options
+        options.tap { |o| self.rpc_spec_path = o[:rpc_spec_path] }
       end
     end
   end

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -59,6 +59,8 @@ module Gruf
       def options
         opts = {}
         VALID_CONFIG_KEYS.each_key do |k|
+          next opts.merge!(k => ENV.fetch('RPC_SPEC_PATH', send(k))) if k == :rpc_spec_path
+
           opts.merge!(k => send(k))
         end
         opts

--- a/spec/gruf/rspec/configuration_spec.rb
+++ b/spec/gruf/rspec/configuration_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Gruf::Rspec::Configuration do
       before { ENV["RPC_SPEC_PATH"] = custom_path }
       after { ENV["RPC_SPEC_PATH"] = nil }
 
-      it "returns the path from the environment variable" do
+      it 'returns the path from the environment variable' do
         expect(options[:rpc_spec_path]).to eq custom_path
       end
     end

--- a/spec/gruf/rspec/configuration_spec.rb
+++ b/spec/gruf/rspec/configuration_spec.rb
@@ -40,14 +40,30 @@ RSpec.describe Gruf::Rspec::Configuration do
   end
 
   describe '.options' do
-    subject { obj.options }
-    before do
-      obj.reset
+    subject(:options) { obj.options }
+
+    before { obj.reset }
+
+    it 'should return the options hash with any configured values' do
+      obj.configure { |c| c.rpc_spec_path = custom_path }
+
+      expect(options).to be_a(Hash)
+      expect(options[:rpc_spec_path]).to eq custom_path
     end
 
-    it 'should return the options hash' do
-      expect(obj.options).to be_a(Hash)
-      expect(obj.options[:rpc_spec_path]).to eq '/spec/rpc/'
+    context 'when RPC_SPEC_PATH is set' do
+      before { ENV["RPC_SPEC_PATH"] = custom_path }
+      after { ENV["RPC_SPEC_PATH"] = nil }
+
+      it "returns the path from the environment variable" do
+        expect(options[:rpc_spec_path]).to eq custom_path
+      end
+    end
+
+    context 'when RPC_SPEC_PATH is not set' do
+      it "returns the default path" do
+        expect(options[:rpc_spec_path]).to eq default_path
+      end
     end
   end
 end

--- a/spec/gruf/rspec/configuration_spec.rb
+++ b/spec/gruf/rspec/configuration_spec.rb
@@ -23,16 +23,19 @@ end
 
 RSpec.describe Gruf::Rspec::Configuration do
   let(:obj) { TestConfiguration.new }
+  let(:default_path) { '/spec/rpc/' }
+  let(:custom_path) { '/spec/gruf/' }
 
   describe '.reset' do
-    subject { obj.rpc_spec_path }
+    subject(:path) { obj.rpc_spec_path }
+
+    before do
+      obj.configure { |c| c.rpc_spec_path = custom_path }
+      obj.reset
+    end
 
     it 'should reset config vars to default' do
-      obj.configure do |c|
-        c.rpc_spec_path = '/spec/gruf/'
-      end
-      obj.reset
-      expect(subject).to_not eq '/spec/gruf/'
+      expect(path).to eq default_path
     end
   end
 


### PR DESCRIPTION
# Summary
According to the [README](https://github.com/bigcommerce/gruf-rspec#rspec-controller-matcher-configuration), the developer should be able to overwrite the default path with the `RPC_SPEC_PATH` environment variable. Currently this is not respected when loading the configuration.

To resolve the problem, this change mainly just relocates the code that fetches the environment variable from the `VALID_CONFIG_KEYS` default config constant, to the `.options` method. There it gives priority to the variable, then if the configuration is set, and then the default value that is set when `.reset` is initially called.

Closes #7 