### PR TITLE
Updated README with latest Ruby version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then add the following code to your `spec_helper.rb`:
 require 'gruf/rspec'
 ``` 
 
-Note that this gem requires at least Ruby 2.4+, Gruf 2.5.1+, and RSpec 3.8+.
+Note that this gem requires at least Ruby 2.6+, Gruf 2.5.1+, and RSpec 3.8+.
 
 ## Usage
 


### PR DESCRIPTION
This PR reflects the Ruby version required by the latest version of this gem (version 0.3.0). The previous Ruby version requirement applied to the last version of this gem (version 0.2.2), but not the latest version, so this updates the README to reflect the latest version of the gem.