### PR TITLE
Add Ruby 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,19 @@ executors:
     parameters:
       ruby-version:
         type: string
-        default: "2.6.5"
+        default: "2.6"
   ruby_2_7:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.7.2"
+        default: "2.7"
+  ruby_3_0:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.0"
 
 commands:
   pre-setup:
@@ -136,3 +142,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_7-rspec"
           e: "ruby_2_7"
+  ruby_3_0:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_0-bundle_audit"
+          e: "ruby_3_0"
+      - rubocop:
+          name: "ruby-3_0-rubocop"
+          e: "ruby_3_0"
+      - rspec-unit:
+          name: "ruby-3_0-rspec"
+          e: "ruby_3_0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Adds support for Ruby 3.0 into test suite
+
 ### 0.3.0
 
 - [#7] Fix issue where RPC_SPEC_PATH defaulting is hardcoded 


### PR DESCRIPTION
Adds support for Ruby 3.0 into the test suite.

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 