### PR TITLE
Remove unnecessarily strict dev dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,21 +38,24 @@ commands:
       - add_ssh_keys
       - checkout
   bundle-install:
+    parameters:
+      gem_cache_key:
+        type: string
+        default: gem-cache-v2
     steps:
-      - run:
-          name: "Install bundler 1.17.3"
-          command: |
-            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler:1.17.3
       - restore_cache:
           keys:
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
-      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}
+            - <<parameters.gem_cache_key>>
+      - run:
+          name: "Bundle install"
+          command: |
+            bundle config set --local path 'vendor/bundle'
+            bundle lock --add-platform x86_64-linux
+            bundle check || bundle install
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   rspec-unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Remove unnecessarily strict dev dependencies
 - Adds support for Ruby 3.0 into test suite
 
 ### 0.3.0

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -35,14 +35,12 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-rspec.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'bundler-audit', '~> 0.6'
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'pry', '>= 0.13'
-  spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'rubocop', '~> 0.82'
-  spec.add_development_dependency 'simplecov', '~> 0.15'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
+  spec.add_development_dependency 'rubocop', '>= 0.82'
+  spec.add_development_dependency 'simplecov', '>= 0.15'
 
-  spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'rspec', '>= 3.8'
+  spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
+  spec.add_runtime_dependency 'rspec', '>= 3.8'
 end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+bundle install
+bundle exec bundle-audit update
+bundle exec bundle-audit check -v
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec rspec


### PR DESCRIPTION
## What?

Removes unnecessarily strict dev dependencies, to allow for bundler 2 and ensure testing against latest.

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 