### PR TITLE
Add support for Ruby 3.2, drop support for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_7:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.7"
   ruby_3_0:
     <<: *ruby_env
     parameters:
@@ -34,6 +28,12 @@ executors:
       ruby-version:
         type: string
         default: "3.1"
+  ruby_3_2:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.2"
 
 commands:
   pre-setup:
@@ -120,7 +120,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -130,7 +130,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -140,7 +140,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
       code-climate:
         type: boolean
         default: false
@@ -152,17 +152,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
-      - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
-      - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
   ruby_3_0:
     jobs:
       - bundle-audit:
@@ -186,3 +175,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_1-rspec"
           e: "ruby_3_1"
+  ruby_3_2:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_2-bundle_audit"
+          e: "ruby_3_2"
+      - rubocop:
+          name: "ruby-3_2-rubocop"
+          e: "ruby_3_2"
+      - rspec-unit:
+          name: "ruby-3_2-rspec"
+          e: "ruby_3_2"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bigcommerce/ruby
+* @bigcommerce/oss-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## What? Why?
+
+
+## How was it tested?
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - spec/**/*
@@ -14,4 +14,7 @@ Lint/AmbiguousOperator:
     - lib/gruf/rspec/configuration.rb
 
 Layout/LineLength:
+  Enabled: false
+
+Style/RedundantConstantBase:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Add support for Ruby 3.2
+- Drop support for Ruby 2.7 (EOL March 2023)
+
 ### 0.6.0
 
 - Add better support for Gruf 2.15+ autoloading in a Rails test environment

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Assistance helpers and custom type for easy testing [Gruf](https://github.com/bi
 gem 'gruf-rspec'
 ```
 
-Note that this gem requires at least Ruby 2.7+, Gruf 2.5.1+, and RSpec 3.8+.
+Note that this gem requires at least Ruby 3.0+, Gruf 2.5.1+, and RSpec 3.8+.
 
 ## Usage
 
@@ -86,7 +86,7 @@ describe 'testing an error' do
 
   subject { run_rpc(:GetThing, request_proto) }
 
-  it 'should fail with the appropriate error' do
+  it 'fails with the appropriate error' do
     expect { subject }.to raise_rpc_error(GRPC::InvalidArgument)
   end
 end
@@ -95,7 +95,7 @@ end
 Or further, even check your serialized error that is passed in metadata:
 
 ```ruby
-it 'should fail with the appropriate error code' do
+it 'fails with the appropriate error code' do
   expect { subject }.to raise_rpc_error(GRPC::InvalidArgument).with_serialized { |err|
     expect(err).to be_a(MyCustomErrorClass)
     expect(err.error_code).to eq 'invalid_request'

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'RSpec assistance library for gruf, including testing helpers'
   spec.homepage      = 'https://github.com/bigcommerce/gruf-rspec'
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0', '< 4'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-rspec.gemspec']


### PR DESCRIPTION
## What? Why?

* Add tested support for Ruby 3.2
* Drops support for Ruby 2.7 (EOL March 2023)

## How was it tested?

rspec, local