### PR TITLE
Add Ruby 3.3 to test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,12 @@ executors:
       ruby-version:
         type: string
         default: "3.2"
+  ruby_3_3:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.3"
 
 commands:
   pre-setup:
@@ -44,7 +50,7 @@ commands:
     parameters:
       gem_cache_key:
         type: string
-        default: gem-cache-v2
+        default: gem-cache-v3
       grpc_ruby_build_procs:
         type: integer
         default: 4
@@ -58,8 +64,6 @@ commands:
           name: "Bundle install"
           command: |
             export GRPC_RUBY_BUILD_PROCS=<<parameters.grpc_ruby_build_procs>>
-            # due to needing GRPC_RUBY_BUILD_PROCS, we need to explicitly install at least this version
-            gem install grpc -v '>= 1.44.0.pre2' --verbose --no-document
             bundle config set --local path 'vendor/bundle'
             bundle lock --add-platform x86_64-linux
             bundle check || bundle install
@@ -186,3 +190,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_2-rspec"
           e: "ruby_3_2"
+  ruby_3_3:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_3-bundle_audit"
+          e: "ruby_3_3"
+      - rubocop:
+          name: "ruby-3_3-rubocop"
+          e: "ruby_3_3"
+      - rspec-unit:
+          name: "ruby-3_3-rspec"
+          e: "ruby_3_3"

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,10 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'bundler-audit', '>= 0.6'
+gem 'pry', '>= 0.13'
+gem 'rspec_junit_formatter', '>= 0.4'
+gem 'rubocop', '>= 0.82'
+gem 'simplecov', '>= 0.15'
+
 gemspec

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -34,13 +34,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-rspec.gemspec']
   spec.require_paths = %w[lib]
 
-  spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'pry', '>= 0.13'
-  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
-  spec.add_development_dependency 'rubocop', '>= 0.82'
-  spec.add_development_dependency 'simplecov', '>= 0.15'
-
   spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
+  spec.add_runtime_dependency 'rake', '>= 12.3'
   spec.add_runtime_dependency 'rspec', '>= 3.8'
   spec.add_runtime_dependency 'zeitwerk', '>= 2'
 end


### PR DESCRIPTION
## What? Why?

Adds Ruby 3.3 to CircleCI test suite.

Ruby 3.3 in some environments requires rake as an explicit dependency. Adds a very loose pin for that here.

## How was it tested?

This PR.