### PR TITLE
Remove unnecessary dependencies and support for older versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'bundler-audit', '>= 0.6'
 gem 'pry', '>= 0.13'
+gem 'rspec', '>= 3.8'
 gem 'rspec_junit_formatter', '>= 0.4'
 gem 'rubocop', '>= 0.82'
 gem 'simplecov', '>= 0.15'

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'rake', '>= 12.3'
-  spec.add_runtime_dependency 'rspec', '>= 3.8'
+  spec.add_runtime_dependency 'rspec-core', '>= 3.8'
+  spec.add_runtime_dependency 'rspec-expectations', '>= 3.8'
   spec.add_runtime_dependency 'zeitwerk', '>= 2'
 end

--- a/lib/gruf/rspec.rb
+++ b/lib/gruf/rspec.rb
@@ -15,16 +15,8 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-begin
-  require 'rspec/core'
-  require 'rspec/expectations'
-  GRUF_RSPEC_NAMESPACE = RSpec
-  GRUF_RSPEC_RUNNER = RSpec
-rescue LoadError # old rspec compat
-  require 'spec'
-  GRUF_RSPEC_NAMESPACE = Spec
-  GRUF_RSPEC_RUNNER = Spec::Runner
-end
+require 'rspec/core'
+require 'rspec/expectations'
 
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
@@ -58,7 +50,7 @@ rescue LoadError
 end
 require_relative 'rspec/railtie' if defined?(::Rails::Railtie)
 
-GRUF_RSPEC_RUNNER.configure do |config|
+RSpec.configure do |config|
   config.include Gruf::Rspec::Helpers
 
   config.define_derived_metadata(file_path: Regexp.new(Gruf::Rspec.rpc_spec_path)) do |metadata|
@@ -89,7 +81,7 @@ GRUF_RSPEC_RUNNER.configure do |config|
   end
 end
 
-GRUF_RSPEC_NAMESPACE::Matchers.define :raise_rpc_error do |expected_error_class|
+RSpec::Matchers.define :raise_rpc_error do |expected_error_class|
   supports_block_expectations
 
   def with_serialized(&block)
@@ -111,7 +103,7 @@ GRUF_RSPEC_NAMESPACE::Matchers.define :raise_rpc_error do |expected_error_class|
   end
 end
 
-GRUF_RSPEC_NAMESPACE::Matchers.define :be_a_successful_rpc do |_|
+RSpec::Matchers.define :be_a_successful_rpc do |_|
   match do |actual|
     if !gruf_controller || actual.is_a?(GRPC::BadStatus) || actual.is_a?(GRPC::Core::CallError)
       false


### PR DESCRIPTION
## What? Why?

I noticed that adding gruf-rspec to a Gemfile adds gems other than the rspec-core and rspec-expectations.
Dependencies on only rspec-core and rspec-expectations are fine because they use only the following APIs:
- RSpec.configure
  - https://rspec.info/documentation/3.8/rspec-core/RSpec/Core/Configuration
- RSpec::Matchers.define
  - https://rspec.info/documentation/3.8/rspec-expectations/RSpec/Matchers

We also care for an older version, which I think is care up to rspec 1.3.2. This project relies on RSpec 3.8+, which I think is unnecessary.
https://www.rubydoc.info/gems/rspec/1.3.2/Spec/Runner
