### PR TITLE
Add Ruby 3.4 support, drop EOL Ruby 3.0/3.1, cleanup rubocop violations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,18 +16,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_3_0:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.0"
-  ruby_3_1:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.1"
   ruby_3_2:
     <<: *ruby_env
     parameters:
@@ -40,6 +28,12 @@ executors:
       ruby-version:
         type: string
         default: "3.3"
+  ruby_3_4:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.4"
 
 commands:
   pre-setup:
@@ -124,7 +118,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -134,7 +128,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -144,7 +138,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
       code-climate:
         type: boolean
         default: false
@@ -156,29 +150,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_0-bundle_audit"
-          e: "ruby_3_0"
-      - rubocop:
-          name: "ruby-3_0-rubocop"
-          e: "ruby_3_0"
-      - rspec-unit:
-          name: "ruby-3_0-rspec"
-          e: "ruby_3_0"
-          code-climate: true
-  ruby_3_1:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_1-bundle_audit"
-          e: "ruby_3_1"
-      - rubocop:
-          name: "ruby-3_1-rubocop"
-          e: "ruby_3_1"
-      - rspec-unit:
-          name: "ruby-3_1-rspec"
-          e: "ruby_3_1"
   ruby_3_2:
     jobs:
       - bundle-audit:
@@ -201,3 +172,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_3-rspec"
           e: "ruby_3_3"
+  ruby_3_4:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_4-bundle_audit"
+          e: "ruby_3_4"
+      - rubocop:
+          name: "ruby-3_4-rubocop"
+          e: "ruby_3_4"
+      - rspec-unit:
+          name: "ruby-3_4-rspec"
+          e: "ruby_3_4"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @bigcommerce/ruby
-* @bigcommerce/oss-maintainers
+* @bigcommerce/ruby @bigcommerce/oss-maintainers

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - spec/**/*
@@ -8,6 +8,12 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
     - log/**/*
+plugins:
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+  - rubocop-thread_safety
 
 Lint/AmbiguousOperator:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Add support for Ruby 3.4
+- Drop support for Ruby 3.0, 3.1 (EOL)
+
+### 1.0.1
+
+- [#23] Only depend on rspec-core/rspec-expectations
+
 ### 1.0.0
 
 - Add support for Ruby 3.2, 3.3

--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,15 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'bundler-audit', '>= 0.6'
 gem 'pry', '>= 0.13'
+gem 'reline'
 gem 'rspec', '>= 3.8'
 gem 'rspec_junit_formatter', '>= 0.4'
 gem 'rubocop', '>= 0.82'
+gem 'rubocop-packaging'
+gem 'rubocop-performance'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'rubocop-thread_safety'
 gem 'simplecov', '>= 0.15'
 
 gemspec

--- a/bin/console
+++ b/bin/console
@@ -16,5 +16,6 @@
 #
 require 'bundler/setup'
 require 'gruf/rspec'
-require 'irb'
-IRB.start(__FILE__)
+
+require 'pry'
+Pry.start(__FILE__)

--- a/gruf-rspec.gemspec
+++ b/gruf-rspec.gemspec
@@ -28,15 +28,15 @@ Gem::Specification.new do |spec|
   spec.description   = 'RSpec assistance library for gruf, including testing helpers'
   spec.homepage      = 'https://github.com/bigcommerce/gruf-rspec'
 
-  spec.required_ruby_version = '>= 3.0', '< 4'
+  spec.required_ruby_version = '>= 3.2', '< 4'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-rspec.gemspec']
   spec.require_paths = %w[lib]
 
-  spec.add_runtime_dependency 'gruf', '~> 2.5', '>= 2.5.1'
-  spec.add_runtime_dependency 'rake', '>= 12.3'
-  spec.add_runtime_dependency 'rspec-core', '>= 3.8'
-  spec.add_runtime_dependency 'rspec-expectations', '>= 3.8'
-  spec.add_runtime_dependency 'zeitwerk', '>= 2'
+  spec.add_dependency 'gruf', '~> 2.5', '>= 2.5.1'
+  spec.add_dependency 'rake', '>= 12.3'
+  spec.add_dependency 'rspec-core', '>= 3.8'
+  spec.add_dependency 'rspec-expectations', '>= 3.8'
+  spec.add_dependency 'zeitwerk', '>= 2'
 end

--- a/lib/autoloader.rb
+++ b/lib/autoloader.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# use Zeitwerk to lazily autoload all the files in the lib directory
+require 'zeitwerk'
+lib_path = __dir__.to_s
+loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
+loader.ignore("#{lib_path}/gruf/rspec/railtie.rb")
+loader.setup

--- a/lib/gruf/rspec.rb
+++ b/lib/gruf/rspec.rb
@@ -15,18 +15,9 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
+require_relative '../autoloader'
 require 'rspec/core'
 require 'rspec/expectations'
-
-# use Zeitwerk to lazily autoload all the files in the lib directory
-require 'zeitwerk'
-lib_path = File.dirname(__dir__)
-loader = ::Zeitwerk::Loader.new
-loader.tag = 'gruf-rspec'
-loader.inflector = ::Zeitwerk::GemInflector.new(__FILE__)
-loader.ignore("#{lib_path}/gruf/rspec/railtie.rb")
-loader.push_dir(lib_path)
-loader.setup
 
 ##
 # Base gruf module
@@ -42,7 +33,7 @@ end
 
 Gruf::Rspec.reset # initial reset
 
-# Attempt to load railtie if we're in a rails environment. This assists with autoloading in a rails rspec context
+# Attempt to load railtie if we're in a Rails environment. This assists with autoloading in a Rails rspec context
 begin
   require 'rails'
 rescue LoadError
@@ -57,6 +48,7 @@ RSpec.configure do |config|
     metadata[:type] = :gruf_controller
   end
 
+  # rubocop:disable ThreadSafety/ClassInstanceVariable
   config.before(:each, type: :gruf_controller) do
     define_singleton_method :run_rpc do |method_name, request, active_call_options: {}, &block|
       @gruf_controller = described_class.new(
@@ -79,6 +71,7 @@ RSpec.configure do |config|
       @gruf_controller
     end
   end
+  # rubocop:enable ThreadSafety/ClassInstanceVariable
 end
 
 RSpec::Matchers.define :raise_rpc_error do |expected_error_class|

--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -70,7 +70,7 @@ module Gruf
       #
       def reset
         VALID_CONFIG_KEYS.each do |k, v|
-          send("#{k}=", v)
+          send(:"#{k}=", v)
         end
         self.rpc_spec_path = ::ENV.fetch('RPC_SPEC_PATH', DEFAULT_RSPEC_PATH).to_s
         options

--- a/lib/gruf/rspec/version.rb
+++ b/lib/gruf/rspec/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Rspec
-    VERSION = '1.0.1.pre'
+    VERSION = '1.1.0.pre'
   end
 end


### PR DESCRIPTION
## What? Why?

- Add support for Ruby 3.4
- Drop support for Ruby 3.0, 3.1 (EOL)

## How was it tested?

Unit suite passes.