### PR TITLE
Add peer expectation to active_call stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-rspec gem.
 
 ### Pending release
 
+- Add peer expectation to active_call stub
+
 ### 1.1.1
 
 - Fix autoloading issue in certain Rails environments

--- a/lib/gruf/rspec/helpers.rb
+++ b/lib/gruf/rspec/helpers.rb
@@ -27,7 +27,15 @@ module Gruf
       #
       def grpc_active_call(options = {})
         md = _build_active_call_metadata(options)
-        double(:grpc_active_call, metadata: md, output_metadata: options.fetch(:output_metadata, {}))
+        double(
+          :grpc_active_call,
+          metadata: md,
+          output_metadata: options.fetch(:output_metadata, {}),
+          # gRPC calls this on initialization of an GRPC::ActiveCall now, so we need to provide stubbed value
+          # (defaulting to nil is fine, but we provide an option to override)
+          # @see https://github.com/grpc/grpc/blob/v1.74.0/src/ruby/lib/grpc/generic/active_call.rb#L113
+          peer: options.fetch(:peer, nil)
+        )
       end
 
       private


### PR DESCRIPTION
## What? Why?

gRPC calls call.peer now on initialization of an GRPC::ActiveCall now, so we need to provide stubbed value
(defaulting to nil is fine, but we provide an option to override)

See https://github.com/grpc/grpc/blob/v1.74.0/src/ruby/lib/grpc/generic/active_call.rb#L113

## How was it tested?

Tested on a grpc application using the `run_rpc` provided method; works as expected.