### PR TITLE
Suppress a runtime warning

### DIFF
--- a/lib/gruf/rspec/configuration.rb
+++ b/lib/gruf/rspec/configuration.rb
@@ -31,7 +31,7 @@ module Gruf
         rpc_spec_path: ENV.fetch('RPC_SPEC_PATH', DEFAULT_RSPEC_PATH).to_s
       }.freeze
 
-      attr_accessor *VALID_CONFIG_KEYS.keys
+      attr_accessor(*VALID_CONFIG_KEYS.keys)
 
       ##
       # Whenever this is extended into a class, setup the defaults


### PR DESCRIPTION
## What? Why?
Suppress a runtime warning:

```
/Users/ydah/gruf-rspec/lib/gruf/rspec/configuration.rb:34: warning: ambiguous `*` has been interpreted as an argument prefix
```

## How was it tested?

Confirmed that the test did not fail and confirmed that the warning no longer appears.